### PR TITLE
Create github-wiki.md

### DIFF
--- a/src/actions/github-wiki.md
+++ b/src/actions/github-wiki.md
@@ -6,7 +6,7 @@ author: "Andrew-Chen-Wang"
 subtitle: "Updates your GitHub wiki by using rsync"
 tags: ["actions","wiki","github-actions"]
 ---
-# Andrew-Chen-Wang/github-wiki-action@v1.1.0
+# Andrew-Chen-Wang/github-wiki-action@v2
 Updates your GitHub wiki by using rsync.
 
 This action updates your repository's wiki
@@ -21,6 +21,13 @@ for you again.
 
 Take a look at [action.yml](https://github.com/Andrew-Chen-Wang/github-wiki-action/blob/master/action.yml)
 for all inputs.
+
+Table of Contents:
+- Usage
+- Features
+- Inspiration
+- License
+- Non-Affiliation with Github Inc.
 
 ---
 ### Usage
@@ -51,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Push Wiki Changes
-      uses: Andrew-Chen-Wang/github-wiki-action@v1.1.0
+      uses: Andrew-Chen-Wang/github-wiki-action@v2
       env:
         # Make sure you have that / at the end. We use rsync 
         # WIKI_DIR's default is wiki/
@@ -59,6 +66,7 @@ jobs:
         GH_PAT: ${{ secrets.GITHUB_TOKEN }}
         GH_MAIL: ${{ secrets.YOUR_EMAIL }}
         GH_NAME: ${{ github.repository_owner }}
+        EXCLUDED_FILES: "a/ b.md"
 ```
 
 If you plan on having a different repository host your wiki
@@ -66,15 +74,21 @@ directory, you're going to need a Personal Access Token instead of the `GITHUB_T
 with the minimal scopes [seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
 
 ---
+### Features
+
+- rsync all your files from one directory (either from the current or other repository) to your GitHub's repo's wiki.
+    - rsyncing from a different repository requires a [GitHub PAT](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
+- Be able to exclude files and directories based on an input of a list.
+
+---
+### Inspiration
 This intended usage was to avoid hosting a private ReadTheDocs
 and instead just use GitHub wiki.
 
 Largely inspired by [wiki-page-creator-action](https://github.com/Decathlon/wiki-page-creator-action)
 and the [issue that arose from it](https://github.com/Decathlon/wiki-page-creator-action/issues/11),
 this GitHub action tries to update the entire wiki based on a single
-directory. It is not as rich in functionality (i.e. the only missing
-functionality is that you can't skip files), but it addresses
-the issue of deleting Wiki pages.
+directory.
 
 ---
 ### License
@@ -94,3 +108,9 @@ the issue of deleting Wiki pages.
    See the License for the specific language governing permissions and
    limitations under the License.
 ```
+
+---
+### Non-Affiliation with GitHub Inc.
+
+This repository/action and its creator is not affiliated with
+GitHub Inc.

--- a/src/actions/github-wiki.md
+++ b/src/actions/github-wiki.md
@@ -1,0 +1,83 @@
+---
+path: "/github-wiki-action"
+title: "github-wiki-action"
+github_url: "https://github.com/Andrew-Chen-Wang/github-wiki-action"
+author: "Andrew-Chen-Wang"
+subtitle: "Updates your GitHub wiki by using rsync"
+tags: ["actions","wiki","github-actions"]
+---
+# github-wiki-action
+Updates your GitHub wiki by using rsync.
+
+This action updates your repository's wiki
+based on a single directory that matches with
+your Wiki's git.
+
+_**It is recommended that you still have a Home.md
+or whatever extension you want instead of MD.**_ This
+is so that GitHub doesn't automatically make a Home.md
+for you again.
+
+Largely inspired by [wiki-page-creator-action](https://github.com/Decathlon/wiki-page-creator-action)
+and the [issue that arose from it](https://github.com/Decathlon/wiki-page-creator-action/issues/11),
+this GitHub action tries to update the entire wiki based on a single
+directory. It is not as rich in functionality, but it addresses
+the issue of deleting Wiki pages.
+
+---
+### Usage
+
+You must have a single wiki page available from the beginning.
+It can be blank, but there must be at least one page that exists.
+You must also have a directory where all your wiki files will
+be located (the default directory is "wiki/").
+
+```yaml
+name: Deploy Wiki
+
+on:
+  push:
+    paths:
+      # Trigger only when wiki directory changes
+      - 'wiki/**'
+    branches:
+      # And only on master branch
+      - master
+
+jobs:
+  deploy-wiki:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Push Wiki Changes
+      uses: Andrew-Chen-Wang/github-wiki-action@v1
+      env:
+        # Make sure you have that / at the end. We use rsync 
+        WIKI_DIR: wiki/
+        GH_PAT: ${{ secrets.GH_PAT }}
+        GH_MAIL: ${{ secrets.YOUR_EMAIL }}
+        GH_NAME: ${{ github.repository_owner }}
+```
+
+You're going to need a Personal Access Token with the minimal scopes of
+[seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
+
+---
+### License
+
+```
+   Copyright 2020 Andrew Chen Wang
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/src/actions/github-wiki.md
+++ b/src/actions/github-wiki.md
@@ -6,23 +6,21 @@ author: "Andrew-Chen-Wang"
 subtitle: "Updates your GitHub wiki by using rsync"
 tags: ["actions","wiki","github-actions"]
 ---
-# github-wiki-action
+# Andrew-Chen-Wang/github-wiki-action@v1.1.0
 Updates your GitHub wiki by using rsync.
 
 This action updates your repository's wiki
 based on a single directory that matches with
-your Wiki's git.
+your Wiki's git. You can use a Wiki directory
+from any repository you wish.
 
 _**It is recommended that you still have a Home.md
 or whatever extension you want instead of MD.**_ This
 is so that GitHub doesn't automatically make a Home.md
 for you again.
 
-Largely inspired by [wiki-page-creator-action](https://github.com/Decathlon/wiki-page-creator-action)
-and the [issue that arose from it](https://github.com/Decathlon/wiki-page-creator-action/issues/11),
-this GitHub action tries to update the entire wiki based on a single
-directory. It is not as rich in functionality, but it addresses
-the issue of deleting Wiki pages.
+Take a look at [action.yml](https://github.com/Andrew-Chen-Wang/github-wiki-action/blob/master/action.yml)
+for all inputs.
 
 ---
 ### Usage
@@ -30,7 +28,9 @@ the issue of deleting Wiki pages.
 You must have a single wiki page available from the beginning.
 It can be blank, but there must be at least one page that exists.
 You must also have a directory where all your wiki files will
-be located (the default directory is "wiki/").
+be located (the default directory is "wiki/"). To include the
+mandatory homepage, have a file in your wiki/ directory
+called Home.md or with any other extension (e.g. rst).
 
 ```yaml
 name: Deploy Wiki
@@ -51,17 +51,30 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Push Wiki Changes
-      uses: Andrew-Chen-Wang/github-wiki-action@v1
+      uses: Andrew-Chen-Wang/github-wiki-action@v1.1.0
       env:
         # Make sure you have that / at the end. We use rsync 
+        # WIKI_DIR's default is wiki/
         WIKI_DIR: wiki/
-        GH_PAT: ${{ secrets.GH_PAT }}
+        GH_PAT: ${{ secrets.GITHUB_TOKEN }}
         GH_MAIL: ${{ secrets.YOUR_EMAIL }}
         GH_NAME: ${{ github.repository_owner }}
 ```
 
-You're going to need a Personal Access Token with the minimal scopes of
-[seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
+If you plan on having a different repository host your wiki
+directory, you're going to need a Personal Access Token instead of the `GITHUB_TOKEN`
+with the minimal scopes [seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
+
+---
+This intended usage was to avoid hosting a private ReadTheDocs
+and instead just use GitHub wiki.
+
+Largely inspired by [wiki-page-creator-action](https://github.com/Decathlon/wiki-page-creator-action)
+and the [issue that arose from it](https://github.com/Decathlon/wiki-page-creator-action/issues/11),
+this GitHub action tries to update the entire wiki based on a single
+directory. It is not as rich in functionality (i.e. the only missing
+functionality is that you can't skip files), but it addresses
+the issue of deleting Wiki pages.
 
 ---
 ### License

--- a/src/actions/github-wiki.md
+++ b/src/actions/github-wiki.md
@@ -19,15 +19,21 @@ or whatever extension you want instead of MD.**_ This
 is so that GitHub doesn't automatically make a Home.md
 for you again.
 
-Take a look at [action.yml](https://github.com/Andrew-Chen-Wang/github-wiki-action/blob/master/action.yml)
-for all inputs.
-
 Table of Contents:
-- Usage
 - Features
+- Usage
+- Inputs
 - Inspiration
 - License
 - Non-Affiliation with Github Inc.
+
+---
+### Features
+
+- rsync all your files from one directory (either from the current or other repository) to your GitHub's repo's wiki.
+    - rsyncing from a different repository requires a [GitHub PAT](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
+- Use the commit message from your repository's git's commit. You can specify a custom one if you want.
+- Be able to exclude files and directories based on an input of a list.
 
 ---
 ### Usage
@@ -74,11 +80,17 @@ directory, you're going to need a Personal Access Token instead of the `GITHUB_T
 with the minimal scopes [seen here.](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
 
 ---
-### Features
+### Inputs
 
-- rsync all your files from one directory (either from the current or other repository) to your GitHub's repo's wiki.
-    - rsyncing from a different repository requires a [GitHub PAT](https://github.com/settings/tokens/new?scopes=repo&description=wiki%20page%20creator%20token)
-- Be able to exclude files and directories based on an input of a list.
+| Argument | Required | Default value | Description |
+|----------|----------|---------------|-------------|
+| WIKI_DIR | No | wiki/ | Directory to rsync files to the wiki.(https://github.com/settings/tokens/new?scopes=repo). |
+| GH_TOKEN | Yes | | The GitHub Token for this action to use. Specify `${{ secrets.GITHUB_TOKEN }}`. |
+| GH_MAIL | Yes | | The email associated with the token. |
+| GH_NAME | Yes | | The username associated with the token. |
+| EXCLUDED_FILES | No | | The files or directories you want to exclude. Note, we use rsync |
+| REPO | No | `${{ github.repository }}` | The target repository. Default is the current repo. If you specify a different repository (e.g. Andrew-Chen-Wang/github-wiki-action), then you must use a PAT. |
+| WIKI_PUSH_MESSAGE | No | Your commit's message | The message to add to your commit to the wiki git |
 
 ---
 ### Inspiration


### PR DESCRIPTION
My GitHub wiki page is based on one that is already listed https://github.com/Decathlon/wiki-page-creator-action but the mine is different in that it allows for any type of file, not just Markdown, usage of `secrets.GITHUB_TOKEN`, exclude files and directory, and allows for deletion of pages if the file is deleted, unlike the other repository in which if the files are deleted, then the wiki DOES NOT reflect that (as in the wiki's page is still there).

Repo: https://github.com/Andrew-Chen-Wang/github-wiki-action

Marketplace: https://github.com/marketplace/actions/github-wiki-action